### PR TITLE
Don't set an automatic URL if the title is nil or empty. Fix issue #85

### DIFF
--- a/app/models/monologue/posts_revision.rb
+++ b/app/models/monologue/posts_revision.rb
@@ -48,14 +48,15 @@ class Monologue::PostsRevision < ActiveRecord::Base
 
     def generate_url
       year = self.published_at.class == ActiveSupport::TimeWithZone ? self.published_at.year : DateTime.now.year
-      self.title = "" if self.title.nil?
-      base_title = "#{year}/#{self.title.parameterize}"
-      url_empty = self.url.nil? || self.url.strip == ""
-      self.url = base_title if url_empty
-      while self.url_exists? && url_empty
-        i ||= 1
-        self.url = "#{base_title}-#{i}"
-        i += 1
+      unless self.title.blank?
+        base_title = "#{year}/#{self.title.parameterize}"
+        url_empty = self.url.nil? || self.url.strip == ""
+        self.url = base_title if url_empty
+        while self.url_exists? && url_empty
+          i ||= 1
+          self.url = "#{base_title}-#{i}"
+          i += 1
+        end
       end
     end
 end


### PR DESCRIPTION
The patch cancel the automatic generation of URL if the title is blank,
