### PR TITLE
Namespace current_user elements to prevent conflicts with main application

### DIFF
--- a/app/controllers/monologue/admin/sessions_controller.rb
+++ b/app/controllers/monologue/admin/sessions_controller.rb
@@ -7,7 +7,7 @@ class Monologue::Admin::SessionsController < Monologue::Admin::BaseController
   def create
     user = Monologue::User.find_by_email(params[:email])
     if user && user.authenticate(params[:password])
-      session[:user_id] = user.id
+      session[:monologue_user_id] = user.id
       redirect_to admin_url, :notice => t("monologue.admin.sessions.messages.logged_in")
     else
       flash.now.alert = t("monologue.admin.sessions.messages.invalid")
@@ -16,7 +16,7 @@ class Monologue::Admin::SessionsController < Monologue::Admin::BaseController
   end
 
   def destroy
-    session[:user_id] = nil
+    session[:monologue_user_id] = nil
     redirect_to admin_url, :notice => t("monologue.admin.sessions.messages.logged_out")
   end
 end

--- a/app/controllers/monologue/application_controller.rb
+++ b/app/controllers/monologue/application_controller.rb
@@ -17,7 +17,7 @@ class Monologue::ApplicationController < ApplicationController
   private
 
     def current_user
-      @current_user ||= Monologue::User.find(session[:user_id]) if session[:user_id]
+      @monologue_current_user ||= Monologue::User.find(session[:monologue_user_id]) if session[:monologue_user_id]
     end
   
   helper_method :current_user


### PR DESCRIPTION
Used `session[:monologue_user_id]` instead of `session[:monologue][:user_id]` so there is no `session[:monologue].try(:[], :user_id)`
