### PR TITLE
Bug in the admin when a comma was at the end of the tag list

### DIFF
--- a/app/models/monologue/post.rb
+++ b/app/models/monologue/post.rb
@@ -30,7 +30,9 @@ class Monologue::Post < ActiveRecord::Base
   def tag!(tags)
     self.tags = tags.map do |tag|
       tag.strip!
-      Monologue::Tag.find_or_create_by_name(tag)
+      if tag.present?
+        Monologue::Tag.find_or_create_by_name(tag)
+      end
     end
   end
 


### PR DESCRIPTION
Bugs corrected when a comma was at the end if the tag list such as Tag1, Tag2,
