### PR TITLE
Correct Issue #106. Logo for open graph protocol with facebook

### DIFF
--- a/app/helpers/monologue/application_helper.rb
+++ b/app/helpers/monologue/application_helper.rb
@@ -48,6 +48,11 @@ module Monologue
       social_icon("facebook", Monologue.facebook_url, Monologue.facebook_url)
     end
 
+    def absolute_image_url(url)
+       return url if url.starts_with? "http"
+       request.protocol + request.host + url
+    end
+
     # TODO: That should be move in TagHelper if I manage to get that loaded
     def tag_url(tag)
       "#{Monologue::Engine.routes.url_helpers.root_path}tags/#{tag.name.downcase}"

--- a/app/views/layouts/monologue/application/_fb_open_graph.html.erb
+++ b/app/views/layouts/monologue/application/_fb_open_graph.html.erb
@@ -2,3 +2,6 @@
 <meta property="og:type" content="<%= controller.action_name == "show" ? "article" : "blog" %>"/>
 <meta property="og:url" content="http://<%= request.host_with_port %><%= request.path.gsub("//","/") %>"/>
 <meta property="og:site_name" content="<%= Monologue.site_name %>"/>
+<% if Monologue.facebook_logo%>
+   <meta property="og:image" content="<%= absolute_image_url(image_path(Monologue.facebook_logo)) %>" />
+<% end  %>

--- a/lib/monologue.rb
+++ b/lib/monologue.rb
@@ -15,6 +15,7 @@ module Monologue
 
                  :facebook_like_locale,
                  :facebook_url,
+                 :facebook_logo, #used in the open graph protocol to display an image when a post is liked
 
                  :google_plus_account_url,
                  :google_plusone_locale,

--- a/spec/dummy/config/initializers/monologue.rb
+++ b/spec/dummy/config/initializers/monologue.rb
@@ -27,6 +27,7 @@ Monologue.sidebar = ["latest_posts", "latest_tweets","categories","tag_cloud"]
 #SOCIAL
 Monologue.twitter_username        = "jipiboily"
 Monologue.facebook_url            = "https://www.facebook.com/jipiboily"
+Monologue.facebook_logo           = 'logo.png'
 Monologue.google_plus_account_url = "https://plus.google.com/u/1/115273180419164295760/posts"
 Monologue.linkedin_url            = "http://www.linkedin.com/in/jipiboily"
 Monologue.github_username         = "jipiboily"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -11,6 +11,18 @@ describe Monologue::ApplicationHelper do
     end
   end
 
+  describe "resolving the absolute image url" do
+    it "should create the fully qualified url for a relative url" do
+      controller.request.host = 'www.domain.com'
+      helper.absolute_image_url('/image.png').should eq "http://www.domain.com/image.png"
+    end
+
+    it "should returns the url for an absolute url" do
+      url ='https://mydomain.com/image.png'
+      helper.absolute_image_url(url).should eq url
+    end
+  end
+
   describe "creating the sidebar section for a title and a block" do
     before(:each) do
       @content = "this is the content"


### PR DESCRIPTION
Option needs to be set in Monologue.rb

`Monologue.facebook_logo = 'logo.png'` 
or
`Monologue.facebook_logo = 'images\logo.png'` 

Absolute path will be resolved using the asset pipeline and a new method in application_helper
