### PR TITLE
Make Disqus embed.js URL protocol relative

### DIFF
--- a/app/views/layouts/monologue/application/_disqus_embed.html.erb
+++ b/app/views/layouts/monologue/application/_disqus_embed.html.erb
@@ -11,7 +11,7 @@
     var dsq = document.createElement('script');
     dsq.type = 'text/javascript';
     dsq.async = true;
-    dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+    dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
     (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
   })();
 </script>


### PR DESCRIPTION
Allow embed.js to be loaded on http or https sites
