### PR TITLE
Fixes #135

### DIFF
--- a/app/helpers/monologue/application_helper.rb
+++ b/app/helpers/monologue/application_helper.rb
@@ -1,8 +1,11 @@
 module Monologue
   module ApplicationHelper
     include Monologue::Engine.routes.url_helpers if ENV["RAILS_ENV"] == "test" # TODO: try and see why this is needed for specs to pass
+    #Why aren't they loaded by default?
+    include Monologue::HtmlHelper
+    include Monologue::TagsHelper
 
-    def monologue_admin_form_for(object, options = { }, &block)
+    def monologue_admin_form_for(object, options = {}, &block)
       options[:builder] = MonologueAdminFormBuilder
       form_for(object, options, &block)
     end
@@ -10,7 +13,6 @@ module Monologue
     def monologue_accurate_title
       content_for?(:title) ? ((content_for :title) + " | #{Monologue.site_name}") : Monologue.site_name
     end
-
 
     def rss_head_link
       tag("link", href: feed_url, rel: "alternate", title: "RSS", type: "application/rss+xml")
@@ -45,14 +47,12 @@ module Monologue
       request.protocol + request.host + url
     end
 
-    def social_icon foundicon, url, setting
+    def social_icon(foundicon, url, setting)
       return if setting.nil? || !setting
       content_tag :a, href: url, class: "social", target: "_blank" do
         content_tag :i, class: "foundicon-#{foundicon}" do # using an empty content tag for foundicons to appear. TODO: try to do otherwise and use only tag method
         end
       end
     end
-
-
   end
 end

--- a/lib/monologue/engine.rb
+++ b/lib/monologue/engine.rb
@@ -4,7 +4,7 @@ require "truncate_html"
 module Monologue
   class Engine < Rails::Engine
     isolate_namespace Monologue
-
+    engine_name 'monologue'
 
     config.generators.test_framework :rspec, view_specs: false, fixture: false
     config.generators.stylesheets false
@@ -14,14 +14,13 @@ module Monologue
     initializer :assets do |config|
       Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'fonts')
     end
-
-
-    initializer 'monologue.action_controller' do |app|
-      ActiveSupport.on_load :action_controller do
-        helper Monologue::HtmlHelper
-        helper Monologue::TagsHelper
-      end
-    end
+    #
+    #initializer 'monologue.action_controller' do |app|
+    #  ActiveSupport.on_load :action_controller do
+    #    helper Monologue::HtmlHelper
+    #    helper Monologue::TagsHelper
+    #  end
+    #end
 
     ENGINE_ROOT = File.join(File.dirname(__FILE__), '../..')
     require "#{ENGINE_ROOT}/deprecations"


### PR DESCRIPTION
Although I am not sure exactly what's going on, loading the helper in the engine was not the right thing to do

The engine should also be named `monologue`

I am not sure why the helpers under `app/helpers` are not loaded automatically. There is something weird here. Adding them explicitly in `ApplicationHelper` does the trick however

Please check the PR and also if you know why the helpers are not loaded as they should be, please let me know why.. I am really curious
