### PR TITLE
Exclude current post's revisions from validation

### DIFF
--- a/app/models/monologue/posts_revision.rb
+++ b/app/models/monologue/posts_revision.rb
@@ -39,8 +39,8 @@ class Monologue::PostsRevision < ActiveRecord::Base
     end
   end
 
-  def last_urls_with_title(title)
-    Monologue::PostsRevision.where("title LIKE ? or title LIKE ?", "#{title}%", "#{title}-%").select(&:title).uniq
+  def last_urls_with_title(title, post_id)
+    Monologue::PostsRevision.where("post_id <> ? AND title LIKE ? OR title LIKE ?", post_id, "#{title}%", "#{title}-%").select(&:title).uniq
   end
 
   private
@@ -51,8 +51,8 @@ class Monologue::PostsRevision < ActiveRecord::Base
       base_title = "#{year}/#{self.title.parameterize}"
       url_empty = self.url.blank?
       self.url = base_title if url_empty
-      past_urls = last_urls_with_title(self.title).map(&:title)
-      if past_urls.include?(self.title)
+      past_urls = last_urls_with_title(self.title, self.post_id).map(&:title)
+      if past_urls.present?
         next_suffix = past_urls.sort.last.split("-").last.to_i + 1
         self.url = "#{base_title}-#{next_suffix}"
       end

--- a/spec/factories/monologue_posts_and_revisions.rb
+++ b/spec/factories/monologue_posts_and_revisions.rb
@@ -6,9 +6,9 @@ FactoryGirl.define do
   end
 
   factory :posts_revision, class: Monologue::PostsRevision do
-    sequence(:title) { |i| "post #{i} | revision 1" }
+    sequence(:title) { |i| "post title #{i} | revision 1" }
     content "this is some text with french accents éàöûù and so on...even html tags like <br />"
-    sequence(:url) { |i| "post/#{i}" }
+    sequence(:url) { |i| "post/ulr#{i}" }
     association :post
     sequence(:published_at) {|i| DateTime.new(2011,1,1,12,0,17) + i.days }
   end

--- a/spec/models/monologue/posts_revision_spec.rb
+++ b/spec/models/monologue/posts_revision_spec.rb
@@ -46,4 +46,11 @@ describe Monologue::PostsRevision do
     pr = Factory(:posts_revision, url: nil, title: "unique title", published_at: DateTime.new(2011))
     pr.url.should == "2011/unique-title-1"
   end
+
+  it "excludes the current post's revisions on URL uniqueness validation" do
+    pr = Factory(:posts_revision, url: nil, title: "unique title", published_at: DateTime.new(2011))
+    pr.content = "Something changed"
+    pr.save
+    pr.url.should == "2011/unique-title"
+  end
 end


### PR DESCRIPTION
When searching thru the candidates for the uniqueness validation, the
current post's revisions should be excluded so it doesn't create a
different url when not necessary.
