### PR TITLE
allow newer version of select2-rails

### DIFF
--- a/monologue.gemspec
+++ b/monologue.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "truncate_html"
   s.add_dependency "jquery-rails"
   s.add_dependency "ckeditor"
-  s.add_dependency 'select2-rails', '3.2.1'
+  s.add_dependency 'select2-rails', '~> 3.2'
 
   s.add_development_dependency "rspec-rails", "~> 2.8"
   s.add_development_dependency 'factory_girl_rails', '~> 1.4.0'
@@ -35,3 +35,4 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "sqlite3"
 end
+


### PR DESCRIPTION
I'm using with spree, which requires select2-rails 3.4.7.
