### PR TITLE
The bcrypt-ruby gem has been renamed to bcrypt.

### DIFF
--- a/monologue.gemspec
+++ b/monologue.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md", "deprecations.rb"]
 
   s.add_dependency "rails", ">= 4.0.4"
-  s.add_dependency "bcrypt-ruby", '~> 3.1.2'
+  s.add_dependency "bcrypt", '~> 3.1.7'
   s.add_dependency "coffee-rails",'~> 4.0.0'
   s.add_dependency "sass-rails",'~> 4.0.0'
   s.add_dependency "truncate_html"


### PR DESCRIPTION
Reference: https://github.com/codahale/bcrypt-ruby/pull/86
