### PR TITLE
Add rails-i18n dependency

### DIFF
--- a/monologue.gemspec
+++ b/monologue.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md", "deprecations.rb"]
 
   s.add_dependency "rails", ">= 4.0.4"
+  s.add_dependency 'rails-i18n'
   s.add_dependency "bcrypt", '~> 3.1.7'
   s.add_dependency "coffee-rails",'~> 4.0.0'
   s.add_dependency "sass-rails",'~> 4.0.0'


### PR DESCRIPTION
So that 6307ec91e7a021e00ad51741f02a71c8f2bb7830 can work out-of-the-box (otherwise, the user has to manually add `gem 'rails-i18n'` to its Gemfile).