### PR TITLE
Added tags as data attribute on post and named classes on tag labels

### DIFF
--- a/app/views/monologue/posts/_post.html.erb
+++ b/app/views/monologue/posts/_post.html.erb
@@ -1,4 +1,4 @@
-<section>
+<section data-tags="<%= post.tags.map(&:name).join(' ') %>">
   <%= render partial: 'monologue/posts/post_header', locals: {post: post} %>
 
   <div class="content" data-monologue="content">

--- a/app/views/monologue/tags/_tag.html.erb
+++ b/app/views/monologue/tags/_tag.html.erb
@@ -1,1 +1,1 @@
-<span class='tag'><%=link_to tag.name, tag_url(tag) %></span>
+<span class='tag tag-<%= tag.name.parameterize %>'><%=link_to tag.name, tag_url(tag) %></span>


### PR DESCRIPTION
I think it's beneficial to be able to target specifically tagged posts. For instance, if I wanted to tag certain posts as `sponsored` and then give them a blue background, I could do the following in css:

```
section[data-tags~=promoted] {
  background: #c3e9ff;
}
``` 

Likewise, I can target the tag label as well:

```
span.tag-promoted {
  background: #c3e9ff;
}
```