### PR TITLE
Use iso8601 format for html validation

### DIFF
--- a/app/views/monologue/posts/_post_header.html.erb
+++ b/app/views/monologue/posts/_post_header.html.erb
@@ -2,7 +2,7 @@
   <h1><%= link_to post.title, post.full_url %></h1>
   <div class="posted">
     <span data-monologue="time">
-      <time datetime="<%= post.published_at %>">
+      <time datetime="<%= post.published_at.iso8601 %>">
         <%= I18n.localize(post.published_at.to_date, format: :long) %>
       </time>
     </span>

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -31,4 +31,13 @@ describe "posts" do
     visit root_path
     page.should_not have_content "I am Marty McFly"
   end
+
+  it "should show published date with valid html5 timestamp" do
+    Factory(:post, published_at: DateTime.new(2000), title: "Y2K", published: true)
+    visit root_path
+    page.should have_content "Y2K"
+    page.should have_content "January 01, 2000"
+    page.should_not have_css "time[datetime='2000-01-01 00:00:00 UTC']"
+    page.should have_css "time[datetime='2000-01-01T00:00:00Z']"
+  end
 end


### PR DESCRIPTION
I was getting a markup validation error that "The literal did not satisfy the time-datetime format." with a datetime value of ```2015-01-02 05:00:00 UTC```. 

This converts the published_at format to iso8601 so that it is a valid format for that attribute.