### PR TITLE
Adds pagination on admin listing of posts

### DIFF
--- a/app/controllers/monologue/admin/posts_controller.rb
+++ b/app/controllers/monologue/admin/posts_controller.rb
@@ -3,7 +3,8 @@ class Monologue::Admin::PostsController < Monologue::Admin::BaseController
   before_filter :load_post, only: [:edit, :update]
   
   def index
-    @posts = Monologue::Post.default
+    @page = params[:page].nil? ? 1 : params[:page]
+    @posts = Monologue::Post.listing_page(@page)
   end
 
   def new

--- a/app/models/monologue/post.rb
+++ b/app/models/monologue/post.rb
@@ -37,19 +37,11 @@ class Monologue::Post < ActiveRecord::Base
   end
 
   def self.page p
-    per_page = Monologue::Config.posts_per_page || 10
-    set_total_pages(per_page)
-    p = (p.nil? ? 0 : p.to_i - 1)
-    offset =  p * per_page
-    self.limit(per_page).offset(offset)
+    paged_results(p, Monologue::Config.posts_per_page || 10, false)
   end
 
   def self.listing_page(p)
-    per_page = Monologue::Config.admin_posts_per_page || 50
-    set_total_pages(per_page)
-    p = (p.nil? ? 0 : p.to_i - 1)
-    offset =  p * per_page
-    default.limit(per_page).offset(offset)
+    paged_results(p, Monologue::Config.admin_posts_per_page || 50, true)
   end
 
   def self.total_pages
@@ -62,6 +54,17 @@ class Monologue::Post < ActiveRecord::Base
 
   private
 
+  def self.paged_results(p, per_page, admin)
+    set_total_pages(per_page)
+    p = (p.nil? ? 0 : p.to_i - 1)
+    offset =  p * per_page
+    if admin
+      default.limit(per_page).offset(offset)
+    else
+      limit(per_page).offset(offset)
+    end
+  end
+
   def generate_url
     return unless self.url.blank?
     year = self.published_at.class == ActiveSupport::TimeWithZone ? self.published_at.year : DateTime.now.year
@@ -71,5 +74,4 @@ class Monologue::Post < ActiveRecord::Base
   def url_do_not_start_with_slash
     errors.add(:url, I18n.t("activerecord.errors.models.monologue/post.attributes.url.start_with_slash")) if self.url.start_with?("/")
   end
-
 end

--- a/app/models/monologue/post.rb
+++ b/app/models/monologue/post.rb
@@ -49,7 +49,7 @@ class Monologue::Post < ActiveRecord::Base
     set_total_pages(per_page)
     p = (p.nil? ? 0 : p.to_i - 1)
     offset =  p * per_page
-    self.default.limit(per_page).offset(offset)
+    default.limit(per_page).offset(offset)
   end
 
   def self.total_pages

--- a/app/models/monologue/post.rb
+++ b/app/models/monologue/post.rb
@@ -44,6 +44,14 @@ class Monologue::Post < ActiveRecord::Base
     self.limit(per_page).offset(offset)
   end
 
+  def self.listing_page p
+    per_page = Monologue::Config.admin_posts_per_page || 50
+    set_total_pages(per_page)
+    p = (p.nil? ? 0 : p.to_i - 1)
+    offset =  p * per_page
+    self.default.limit(per_page).offset(offset)
+  end
+
   def self.total_pages
     @number_of_pages
   end

--- a/app/models/monologue/post.rb
+++ b/app/models/monologue/post.rb
@@ -44,7 +44,7 @@ class Monologue::Post < ActiveRecord::Base
     self.limit(per_page).offset(offset)
   end
 
-  def self.listing_page p
+  def self.listing_page(p)
     per_page = Monologue::Config.admin_posts_per_page || 50
     set_total_pages(per_page)
     p = (p.nil? ? 0 : p.to_i - 1)

--- a/app/views/monologue/admin/posts/_pagination.html.erb
+++ b/app/views/monologue/admin/posts/_pagination.html.erb
@@ -1,0 +1,9 @@
+<div id="pagination">
+  <% if @posts.total_pages > 1 && @posts.total_pages != @page.to_i %>
+    <%= link_to t(".older_posts"), admin_posts_page_path(@page.to_i+1), class: "older_posts" %>
+  <% end %>
+
+  <% if @posts.total_pages > 1 && @page.to_i > 1 %>
+    <%= link_to t(".newer_posts"), admin_posts_page_path(@page.to_i-1), class: "newer_posts" %>
+  <% end %>
+</div>

--- a/app/views/monologue/admin/posts/index.html.erb
+++ b/app/views/monologue/admin/posts/index.html.erb
@@ -20,3 +20,7 @@
     <% end %>
   </tbody>
 </table>
+
+<% if @page %>
+  <%= render partial: "pagination" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Monologue::Engine.routes.draw do
 
   namespace :admin, path: "monologue" do
     get "/" => "posts#index", as:  "" # responds to admin_url and admin_path
+    get "/page/:page", to:  "posts#index", as:  "posts_page"
     get "logout" => "sessions#destroy"
     get "login" => "sessions#new"
     resources :sessions

--- a/lib/monologue/configuration.rb
+++ b/lib/monologue/configuration.rb
@@ -3,35 +3,35 @@ module Monologue
     include ConfigurationExtensions
 
     attr_accessor :disqus_shortname,
-                    :site_name,
-                    :site_subtitle,
-                    :site_url,
-                    :meta_description,
-                    :meta_keyword,
+                  :site_name,
+                  :site_subtitle,
+                  :site_url,
+                  :meta_description,
+                  :meta_keyword,
 
-                    :show_rss_icon,
+                  :show_rss_icon,
 
-                    :twitter_username,
-                    :twitter_locale,
+                  :twitter_username,
+                  :twitter_locale,
 
-                    :facebook_like_locale,
-                    :facebook_url,
-                    :facebook_logo, #used in the open graph protocol to display an image when a post is liked
+                  :facebook_like_locale,
+                  :facebook_url,
+                  :facebook_logo, #used in the open graph protocol to display an image when a post is liked
 
-                    :google_plus_account_url,
-                    :google_plusone_locale,
+                  :google_plus_account_url,
+                  :google_plusone_locale,
 
-                    :linkedin_url,
+                  :linkedin_url,
 
-                    :github_username,
+                  :github_username,
 
-                    :admin_force_ssl,
-                    :posts_per_page,
-                    :admin_posts_per_page,
-                    :google_analytics_id,
-                    :gauge_analytics_site_id,
-                    :layout,
-                    :sidebar
+                  :admin_force_ssl,
+                  :posts_per_page,
+                  :admin_posts_per_page,
+                  :google_analytics_id,
+                  :gauge_analytics_site_id,
+                  :layout,
+                  :sidebar
 
   end
 

--- a/lib/monologue/configuration.rb
+++ b/lib/monologue/configuration.rb
@@ -27,6 +27,7 @@ module Monologue
 
                     :admin_force_ssl,
                     :posts_per_page,
+                    :admin_posts_per_page,
                     :google_analytics_id,
                     :gauge_analytics_site_id,
                     :layout,

--- a/spec/requests/admin/posts_spec.rb
+++ b/spec/requests/admin/posts_spec.rb
@@ -10,6 +10,14 @@ describe "posts" do
       visit admin_posts_path
       page.should have_content "Add a monologue"
     end
+
+    it "can access post's admin with pagination" do
+      Factory(:post, title: "my first title")
+      Factory(:post, title: "my second title")
+      Monologue::Config.admin_posts_per_page = 1
+      visit admin_posts_page_path page: 1
+      page.should have_content "Older Posts"
+    end
     
     it "can create new post" do
       visit new_admin_post_path


### PR DESCRIPTION
Adds pagination to the table of posts in the admin section. Defaults to 50 per page or you can set using a new config option: `admin_posts_per_page`.
