### PR TITLE
Renamed pt.yml localization file to pt-BR.yml and changed language from pt_BR to pt-BR

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt_BR:
+pt-BR:
   monologue:
     posts:
       pagination:


### PR DESCRIPTION
The original pt.yml file contained brazilian portuguese localized strings. Therefore, it should be named pt-BR.yml.

Also, region-localized languages are more commonly referenced using hyphen instead of underscore.