### PR TITLE
Fixed view receiving error notice when post saved successfully

### DIFF
--- a/app/views/layouts/monologue/admin.html.erb
+++ b/app/views/layouts/monologue/admin.html.erb
@@ -12,7 +12,7 @@
   <% end %>
   <div class="container">
     <% flash.each do |name, msg| %>
-      <%= content_tag :div, msg, id: "flash_#{name}", class: (name == :notice ? "alert alert-info" : "alert alert-error") %>
+      <%= content_tag :div, msg, id: "flash_#{name}", class: (name == 'notice' ? "alert alert-info" : "alert alert-error") %>
     <% end %>
 
     <%= yield %>


### PR DESCRIPTION
After successfully saving a post, the if else statement within the flash.each loop (inside admin.html.erb) returns "alert alert-error", along with a message stating the post was successfully saved. Replacing the notice symbol with the string 'notice' has solved the issue and now returns the correct class name.