### PR TITLE
Revert "Improved performance on tag frequency calculation"

### DIFF
--- a/app/controllers/monologue/application_controller.rb
+++ b/app/controllers/monologue/application_controller.rb
@@ -10,7 +10,7 @@ class Monologue::ApplicationController < ApplicationController
   end
 
   def all_tags
-    @tags  =  Monologue::Tag.with_frequency.order("name")
+    @tags = Monologue::Tag.order("name").select{|t| t.frequency>0}
     #could use minmax here but it's only supported with ruby > 1.9'
     @tags_frequency_min = @tags.map{|t| t.frequency}.min
     @tags_frequency_max = @tags.map{|t| t.frequency}.max

--- a/app/models/monologue/tag.rb
+++ b/app/models/monologue/tag.rb
@@ -7,18 +7,7 @@ class Monologue::Tag < ActiveRecord::Base
     self.posts.published
   end
 
-  def self.with_frequency
-    self
-      .select("name, COUNT(*) as frequency")
-      .joins("INNER JOIN monologue_taggings ON monologue_taggings.tag_id = monologue_tags.id")
-      .joins("INNER JOIN monologue_posts    ON monologue_posts.id        = monologue_taggings.post_id")
-      .where("monologue_posts.published = 't'")
-      .group("name")
-      .having("COUNT(*) > 0")
-  end
-
   def frequency
-    self.attributes["frequency"].nil? ? posts_with_tag.size : self.attributes["frequency"].to_i
+    posts_with_tag.size
   end
-  
 end


### PR DESCRIPTION
Unfortunately a test is failing. 

`tag category Viewing the tag category should only display the frequency of tags used by published post`
Can you ensure that all tests are passing and resubmit PR? thanks @jcarreti 