### PR TITLE
Preventing N tag queries on post index pages

### DIFF
--- a/app/controllers/monologue/posts_controller.rb
+++ b/app/controllers/monologue/posts_controller.rb
@@ -1,7 +1,7 @@
 class Monologue::PostsController < Monologue::ApplicationController
   def index
     @page = params[:page].nil? ? 1 : params[:page]
-    @posts = Monologue::Post.page(@page).includes(:user).published
+    @posts = Monologue::Post.page(@page).includes(:user, :tags).published
   end
 
   def show


### PR DESCRIPTION
Every [post partial](https://github.com/jipiboily/monologue/blob/master/app/views/monologue/posts/_post.html.erb#L1) calls `.tags` which causes a query per post.  Adding `:tags` to the includes should bring this down to a single query instead of N queries.